### PR TITLE
Add firebase path prop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-data-beta
     - env: EMBER_TRY_SCENARIO=ember-data-canary
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -248,25 +248,40 @@ Most of the time, we don't want to use the `hasMany()` relationship in our model
 To solve those 2 problems above, use `hasFiltered()` relationship. It has the same parameters as `store.query()` and it also works with infinite scrolling as explained above.
 
 ```javascript
-// app/models/user
+// app/models/post
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 
 import hasFiltered from 'emberfire-utils/utils/has-filtered';
 
 export default Model.extend({
-  photoURL: attr('string'),
-  username: attr('string'),
-  posts: hasFiltered('post', {
-    path: 'userFeeds/$id',
-    cacheId: '$id_posts',
+  title: attr('string'),
+
+  _innerReferencePath: attr('string'),
+
+  comments: hasFiltered('comment', {
+    cacheId: '$id_comments',
+    path: '/comments/$innerReferencePath',
     limitToFirst: 10,
   })
 });
 
 ```
 
-Notice the `$id`. It's a keyword that will be replaced by the model's ID.
+Notice the following:
+
+* `$id`
+  * This is a keyword that will be replaced by the model's ID.
+  * This works for both `cacheId` and `path`.
+* `_innerReferencePath`
+  * This will be replaced by the inner Firebase reference path of the model.
+  * If `post` model lives in `/posts/forum_a/post_a`, the value would be `/forum_a/post_a`.
+  * This is a client-side only property. It won't be persisted in the DB when you save the record.
+* `$innerReferencePath`
+  * This is a keyword that will be replaced by `_innerReferencePath`.
+  * This only works for `path`.
+  * Won't work when `_innerReferencePath` isn't defined.
+  * This is useful for when let's say your comments lives in `/comments/<forum_id>/<post_id>` and you know the value of the `<post_id>` through `$id` but don't know the value of `<forum_id>`.
 
 > `hasFiltered()` are read only.
 

--- a/addon/adapters/firebase-flex.js
+++ b/addon/adapters/firebase-flex.js
@@ -479,7 +479,14 @@ export default Adapter.extend({
    * @private
    */
   _getGetSnapshotWithId(snapshot) {
-    return assign({}, { id: snapshot.key }, snapshot.val());
+    const ref = snapshot.ref;
+    const referencePath = ref.toString().substring(ref.root.toString().length);
+    const innerReferencePath = referencePath.substring(
+        referencePath.search('/'));
+
+    return assign({}, { id: snapshot.key }, snapshot.val(), {
+      _innerReferencePath: innerReferencePath,
+    });
   },
 
   /**

--- a/addon/serializers/firebase-flex.js
+++ b/addon/serializers/firebase-flex.js
@@ -20,8 +20,10 @@ export default EmberFireSerializer.extend({
     const changedAttributes = assign({}, snapshot.changedAttributes());
 
     snapshot.eachAttribute((key, attribute) => {
-      if (changedAttributes.hasOwnProperty(key)) {
-        fanout[`${path}/${key}`] = snapshot.attr(key);
+      if (key !== '_innerReferencePath') {
+        if (changedAttributes.hasOwnProperty(key)) {
+          fanout[`${path}/${key}`] = snapshot.attr(key);
+        }
       }
     });
 

--- a/addon/utils/has-filtered.js
+++ b/addon/utils/has-filtered.js
@@ -22,6 +22,8 @@ export default function hasFiltered(modelName, rawQuery = {}) {
 
       if (query.hasOwnProperty('path')) {
         query.path = query.path.replace('$id', this.get('id'));
+        query.path = query.path.replace(
+            '$innerReferencePath', this.get('_innerReferencePath'));
       }
 
       return PromiseArray.create({

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -90,8 +90,8 @@ module.exports = {
     {
       name: 'ember-data-release',
       npm: {
-        dependencies: {
-          'ember-data': 'components/ember-data#release'
+        devDependencies: {
+          'ember-data': 'emberjs/data#release'
         },
         resolutions: {
           'ember-data': 'release'
@@ -101,8 +101,8 @@ module.exports = {
     {
       name: 'ember-data-beta',
       npm: {
-        dependencies: {
-          'ember-data': 'components/ember-data#beta'
+        devDependencies: {
+          'ember-data': 'emberjs/data#beta'
         },
         resolutions: {
           'ember-data': 'beta'
@@ -112,8 +112,8 @@ module.exports = {
     {
       name: 'ember-data-canary',
       npm: {
-        dependencies: {
-          'ember-data': 'components/ember-data#canary'
+        devDependencies: {
+          'ember-data': 'emberjs/data#canary'
         },
         resolutions: {
           'ember-data': 'canary'

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -113,7 +113,7 @@ module.exports = {
       name: 'ember-data-canary',
       npm: {
         devDependencies: {
-          'ember-data': 'emberjs/data#canary'
+          'ember-data': 'emberjs/data#master'
         },
         resolutions: {
           'ember-data': 'canary'

--- a/tests/dummy/app/models/blog-post.js
+++ b/tests/dummy/app/models/blog-post.js
@@ -6,4 +6,5 @@ export default Model.extend({
   message: attr('string'),
   timestamp: attr('number'),
   author: belongsTo('user'),
+  _innerReferencePath: attr('string'),
 });

--- a/tests/unit/adapters/firebase-flex-test.js
+++ b/tests/unit/adapters/firebase-flex-test.js
@@ -346,6 +346,7 @@ test('should return fetched record', async function(assert) {
     message: 'Post A',
     timestamp: 12345,
     author: 'user_a',
+    _innerReferencePath: '/post_a',
   });
 });
 

--- a/tests/unit/serializers/firebase-flex-test.js
+++ b/tests/unit/serializers/firebase-flex-test.js
@@ -23,3 +23,24 @@ test('should serialize record to Firebase fanout', function(assert) {
     '/blogPosts/post_a/timestamp': 12345,
   });
 });
+
+test('should remove _innerReferencePath from fanout', function(assert) {
+  assert.expect(1);
+
+  // Arrange
+  const post = this.subject({
+    id: 'post_a',
+    message: 'Post',
+    timestamp: 12345,
+    _innerReferencePath: '/post_a',
+  });
+
+  // Act
+  const serializedRecord = post.serialize();
+
+  // Assert
+  assert.deepEqual(serializedRecord, {
+    '/blogPosts/post_a/message': 'Post',
+    '/blogPosts/post_a/timestamp': 12345,
+  });
+});

--- a/tests/unit/utils/has-filtered-test.js
+++ b/tests/unit/utils/has-filtered-test.js
@@ -10,10 +10,10 @@ import stubPromise from 'dummy/tests/helpers/stub-promise';
 module('Unit | Utility | has filtered');
 
 test('should return a computed promise array when calling hasFiltered', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   // Arrange
-  const EXPECTED = [{
+  const queryResult = [{
     id: 'xfoo',
     value: 'foo',
   }, {
@@ -23,19 +23,31 @@ test('should return a computed promise array when calling hasFiltered', function
     id: 'zbar',
     value: 'bar',
   }];
-  let EO = EmberObject.extend({
-    store: { query: sinon.stub().returns(stubPromise(true, EXPECTED)) },
-    foo: hasFiltered('model'),
+  const queryStub = sinon.stub().returns(stubPromise(true, queryResult));
+  const EO = EmberObject.extend({
+    store: { query: queryStub },
+
+    id: 'lala',
+    _innerReferencePath: 'land',
+
+    foo: hasFiltered('model', {
+      cacheId: 'foo_$id',
+      path: 'foo_$id_bar_$innerReferencePath',
+    }),
   });
-  let object = EO.create();
+  const object = EO.create();
 
   // Act
-  let promiseArray = object.get('foo');
+  const promiseArray = object.get('foo');
 
   // Assert
   return wait().then(() => {
-    let actual = promiseArray.get('content');
+    const result = promiseArray.get('content');
 
-    assert.equal(actual, EXPECTED);
+    assert.ok(queryStub.calledWithExactly('model', {
+      cacheId: 'foo_lala',
+      path: 'foo_lala_bar_land',
+    }));
+    assert.equal(result, queryResult);
   });
 });


### PR DESCRIPTION
- Add support for `_innerReferencePath` client-side only model property
  - When `_innerReferencePath: DS.attr('string')` is provided in the model, this will contain the inner Firebase reference path it uses. (e.g. If path is on `/posts/forum_a/post_a`, its value will be `/forum_a/post_a`.
  - This property will only live in the client-side, it won't be persisted in the DB when calling save.
  - See `hasFiltered()` README for more practical usage on this.
- Fix ember-data config in ember-try (also temporarily allow failures to ember-data-beta to keep tests green)