### PR TITLE
Rewrite serializer

### DIFF
--- a/addon/serializers/firebase-flex.js
+++ b/addon/serializers/firebase-flex.js
@@ -10,41 +10,124 @@ import EmberFireSerializer from 'emberfire/serializers/firebase';
  */
 export default EmberFireSerializer.extend({
   /**
+   * Builds a fanout object whenever a record is saved
+   *
    * @param {DS.Snapshot} snapshot
+   * @param {Object} [options={}]
    * @return {Object} Fanout object for Firebase
    */
-  serialize(snapshot) {
+  serialize(snapshot, options = {}) {
     const fanout = {};
-    const path = this._getPath(snapshot);
 
-    for (const key in snapshot.changedAttributes()) {
-      if (key !== '_innerReferencePath') {
-        fanout[`${path}/${key}`] = snapshot.attr(key);
+    snapshot.eachAttribute((key, attribute) => {
+      if (snapshot.changedAttributes()[key]) {
+        if (key !== options.innerReferencePathName) {
+          this.serializeAttribute(snapshot, fanout, key, attribute);
+        }
       }
-    }
+    });
+
+    this.serializeInclude(snapshot, fanout);
 
     return fanout;
   },
 
   /**
+   * Serializes an attribute to the fanout path
+   *
    * @param {DS.Snapshot} snapshot
-   * @return {string} Firebase path
-   * @private
+   * @param {Object} fanout
+   * @param {string} key
+   * @param {Object} attribute
    */
-  _getPath(snapshot) {
-    if (snapshot.adapterOptions &&
-        snapshot.adapterOptions.hasOwnProperty('path')) {
-      let pathPrefix = snapshot.adapterOptions.path;
+  serializeAttribute(snapshot, fanout, key, attribute) {
+    this._super(...arguments);
 
-      if (pathPrefix) {
-        if (!pathPrefix.startsWith('/')) {
-          pathPrefix = `/${pathPrefix}`;
+    const keyPath = this._getKeyPath(snapshot, key);
+
+    fanout[keyPath] = fanout[key];
+
+    delete fanout[key];
+  },
+
+  /**
+   * Serializes adapter option's include to the fanout
+   *
+   * @param {DS.Snapshot} snapshot
+   * @param {Object} fanout
+   */
+  serializeInclude(snapshot, fanout) {
+    const adapterOptions = snapshot.adapterOptions;
+
+    if (adapterOptions && adapterOptions.hasOwnProperty('include')) {
+      const include = adapterOptions.include;
+
+      for (const key in include) {
+        if (include.hasOwnProperty(key)) {
+          let parsedKey = key.replace(':id', snapshot.id);
+
+          if (key.includes('$id')) {
+            console.warn('DEPRECATION: adapterOptions.include will now use ' +
+                ':id instead of $id');
+
+            parsedKey = key.replace('$id', snapshot.id);
+          }
+
+          fanout[parsedKey] = include[key];
         }
-
-        return `${pathPrefix}/${snapshot.id}`;
       }
     }
+  },
 
-    return `/${camelize(pluralize(snapshot.modelName))}/${snapshot.id}`;
+  /**
+   * Builds a path for a model's attribute
+   *
+   * @param {DS.Snapshot} snapshot
+   * @param {string} key
+   * @return {string} Path
+   * @private
+   */
+  _getKeyPath(snapshot, key) {
+    const customPath = this._getCustomPath(snapshot);
+    const snapshotId = snapshot.id;
+    const keyPath = camelize(key);
+
+    if (customPath) {
+      return `${customPath}/${snapshotId}/${keyPath}`;
+    } else {
+      const modelPath = this._getPathForType(snapshot.modelName);
+
+      return `${modelPath}/${snapshotId}/${keyPath}`;
+    }
+  },
+
+  /**
+   * Determines a path name for a given type
+   *
+   * @param {string} modelName
+   * @return {string} Path
+   * @private
+   */
+  _getPathForType(modelName) {
+    const camelized = camelize(modelName);
+
+    return pluralize(camelized);
+  },
+
+  /**
+   * Determines the custom path value
+   *
+   * @param {DS.Snapshot} snapshot
+   * @return {string} Path
+   * @private
+   */
+  _getCustomPath(snapshot) {
+    const adapterOptions = snapshot.adapterOptions;
+
+    if (adapterOptions && adapterOptions.hasOwnProperty('path')) {
+      return adapterOptions.path;
+    }
+
+    return null;
   },
 });

--- a/addon/transforms/timestamp.js
+++ b/addon/transforms/timestamp.js
@@ -1,0 +1,26 @@
+/** @module emberfire-utils */
+import Transform from 'ember-data/transform';
+
+import firebase from 'firebase';
+
+/**
+ * @class Timestamp
+ * @namespace Transform
+ * @extends DS.Transform
+ */
+export default Transform.extend({
+  /**
+   * @param {number} serialized
+   * @return {date} Deserialized object
+   */
+  deserialize(serialized) {
+    return new Date(serialized);
+  },
+
+  /**
+   * @return {Object} Firebase server timestamp
+   */
+  serialize() {
+    return firebase.database.ServerValue.TIMESTAMP;
+  },
+});

--- a/addon/utils/has-filtered.js
+++ b/addon/utils/has-filtered.js
@@ -34,8 +34,21 @@ export default function hasFiltered(modelName, rawQuery = {}) {
         query.path = query.path.replace('$id', this.get('id'));
 
         query.path = query.path.replace(':id', this.get('id'));
+
+        const modelName = this.get('constructor.modelName');
+        const adapter = this.get('store').adapterFor(modelName);
+        const innerReferencePathName = adapter.get('innerReferencePathName');
+
+        if (query.path.includes('$innerReferencePath')) {
+          console.warn('DEPRECATION: hasFiltered() path will now use ' +
+              ':innerReferencePath instead of $innerReferencePath');
+
+          query.path = query.path.replace(
+              '$innerReferencePath', this.get(innerReferencePathName));
+        }
+
         query.path = query.path.replace(
-            '$innerReferencePath', this.get('_innerReferencePath'));
+            ':innerReferencePath', this.get(innerReferencePathName));
       }
 
       return PromiseArray.create({

--- a/app/transforms/timestamp.js
+++ b/app/transforms/timestamp.js
@@ -1,0 +1,1 @@
+export { default } from 'emberfire-utils/transforms/timestamp';

--- a/tests/acceptance/find-record-test.js
+++ b/tests/acceptance/find-record-test.js
@@ -20,7 +20,7 @@ test('should display record when fetched', function(assert) {
   andThen(() => {
     assert.equal(find(postId).text().trim(), 'post_a');
     assert.equal(find(postMessage).text().trim(), 'Post A');
-    assert.equal(find(postTimestamp).text().trim(), '12345');
+    assert.equal(find(postTimestamp).text().trim(), new Date('2017-01-01'));
     assert.equal(find(postAuthor).text().trim(), 'User A');
   });
 });

--- a/tests/acceptance/query-record-test.js
+++ b/tests/acceptance/query-record-test.js
@@ -26,7 +26,7 @@ test('should query record with path as reference to model', function(assert) {
   andThen(() => {
     assert.equal(find(postId).text().trim(), 'post_a');
     assert.equal(find(postMessage).text().trim(), 'Post A');
-    assert.equal(find(postTimestamp).text().trim(), '12345');
+    assert.equal(find(postTimestamp).text().trim(), new Date('2017-01-01'));
     assert.equal(find(postAuthor).text().trim(), 'User A');
   });
 });
@@ -42,7 +42,7 @@ test('should query record with path as direct representation of model', function
   andThen(() => {
     assert.equal(find(commentId).text().trim(), 'comment_a');
     assert.equal(find(commentMessage).text().trim(), 'Comment A');
-    assert.equal(find(commentTimestamp).text().trim(), '12345');
+    assert.equal(find(commentTimestamp).text().trim(), new Date('2017-01-01'));
     assert.equal(find(commentAuthor).text().trim(), 'User B');
   });
 });
@@ -58,7 +58,7 @@ test('should query record without path', function(assert) {
   andThen(() => {
     assert.equal(find(postId).text().trim(), 'post_a');
     assert.equal(find(postMessage).text().trim(), 'Post A');
-    assert.equal(find(postTimestamp).text().trim(), '12345');
+    assert.equal(find(postTimestamp).text().trim(), new Date('2017-01-01'));
     assert.equal(find(postAuthor).text().trim(), 'User A');
   });
 });

--- a/tests/acceptance/query-test.js
+++ b/tests/acceptance/query-test.js
@@ -26,7 +26,7 @@ test('should query records with path as reference to model', function(assert) {
   andThen(() => {
     assert.equal(find(postId).text().trim(), 'post_a');
     assert.equal(find(postMessage).text().trim(), 'Post A');
-    assert.equal(find(postTimestamp).text().trim(), '12345');
+    assert.equal(find(postTimestamp).text().trim(), new Date('2017-01-01'));
     assert.equal(find(postAuthor).text().trim(), 'User A');
   });
 });
@@ -42,7 +42,7 @@ test('should query records with path as direct representation of model', functio
   andThen(() => {
     assert.equal(find(commentId).text().trim(), 'comment_a');
     assert.equal(find(commentMessage).text().trim(), 'Comment A');
-    assert.equal(find(commentTimestamp).text().trim(), '12345');
+    assert.equal(find(commentTimestamp).text().trim(), new Date('2017-01-01'));
     assert.equal(find(commentAuthor).text().trim(), 'User B');
   });
 });

--- a/tests/acceptance/update-record-test.js
+++ b/tests/acceptance/update-record-test.js
@@ -20,7 +20,7 @@ test('should update record', function(assert) {
   andThen(() => {
     assert.equal(find(postId).text().trim(), 'post_a');
     assert.equal(find(postMessage).text().trim(), 'Foo');
-    assert.equal(find(postTimestamp).text().trim(), '12345');
+    assert.equal(find(postTimestamp).text().trim(), new Date('2017-01-01'));
     assert.equal(find(postAuthor).text().trim(), 'User B');
   });
 });

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,4 +1,5 @@
 import FirebaseFlexAdapter from 'emberfire-utils/adapters/firebase-flex';
 
 export default FirebaseFlexAdapter.extend({
+  innerReferencePathName: 'innerReferencePath',
 });

--- a/tests/dummy/app/controllers/comments.js
+++ b/tests/dummy/app/controllers/comments.js
@@ -22,9 +22,9 @@ export default Controller.extend({
 
     newComment.save({
       adapterOptions: {
-        path: '/comments/post_a',
+        path: 'comments/post_a',
         include: {
-          '/comments/post_a/:id/author': 'user_a',
+          'comments/post_a/:id/author': 'user_a',
         },
       },
     });
@@ -46,7 +46,7 @@ export default Controller.extend({
   async handleQueryWithPathClick() {
     const comments = await this.get('store').query('comment', {
       cacheId: 'cache-id',
-      path: '/comments/post_a',
+      path: 'comments/post_a',
       limitToFirst: 1,
     });
 

--- a/tests/dummy/app/controllers/posts.js
+++ b/tests/dummy/app/controllers/posts.js
@@ -23,7 +23,7 @@ export default Controller.extend({
     newPost.save({
       adapterOptions: {
         include: {
-          '/blogPosts/:id/author': 'user_a',
+          'blogPosts/:id/author': 'user_a',
         },
       },
     });
@@ -41,7 +41,7 @@ export default Controller.extend({
     post.save({
       adapterOptions: {
         include: {
-          '/blogPosts/post_a/author': user.get('id'),
+          'blogPosts/post_a/author': user.get('id'),
         },
       },
     });

--- a/tests/dummy/app/models/blog-post.js
+++ b/tests/dummy/app/models/blog-post.js
@@ -4,7 +4,7 @@ import attr from 'ember-data/attr';
 
 export default Model.extend({
   message: attr('string'),
-  timestamp: attr('number'),
+  timestamp: attr('timestamp'),
   author: belongsTo('user'),
-  _innerReferencePath: attr('string'),
+  innerReferencePath: attr('string'),
 });

--- a/tests/dummy/app/models/comment.js
+++ b/tests/dummy/app/models/comment.js
@@ -4,7 +4,8 @@ import attr from 'ember-data/attr';
 
 export default Model.extend({
   message: attr('string'),
-  timestamp: attr('number'),
+  timestamp: attr('timestamp'),
   author: belongsTo('user'),
   post: belongsTo('blog-post'),
+  innerReferencePath: attr('string'),
 });

--- a/tests/helpers/fixture-data.js
+++ b/tests/helpers/fixture-data.js
@@ -6,12 +6,12 @@ export default function getFixtureData() {
     blogPosts: {
       post_a: {
         message: 'Post A',
-        timestamp: 12345,
+        timestamp: 1483228800000,
         author: 'user_a',
       },
       post_b: {
         message: 'Post B',
-        timestamp: 12345,
+        timestamp: 1483228800000,
         author: 'user_a',
       },
     },
@@ -19,12 +19,12 @@ export default function getFixtureData() {
       post_a: {
         comment_a: {
           message: 'Comment A',
-          timestamp: 12345,
+          timestamp: 1483228800000,
           author: 'user_b',
         },
         comment_b: {
           message: 'Comment B',
-          timestamp: 12345,
+          timestamp: 1483228800000,
           author: 'user_b',
         },
       },

--- a/tests/unit/adapters/firebase-flex-test.js
+++ b/tests/unit/adapters/firebase-flex-test.js
@@ -5,6 +5,7 @@ import run, { next } from 'ember-runloop';
 
 import createOfflineRef from 'dummy/tests/helpers/create-offline-ref';
 import destroyFirebaseApps from 'dummy/tests/helpers/destroy-firebase-apps';
+import firebase from 'firebase';
 import sinon from 'sinon';
 import stubFirebase from 'dummy/tests/helpers/stub-firebase';
 import unStubFirebase from 'dummy/tests/helpers/unstub-firebase';
@@ -65,8 +66,10 @@ test('should update Firebase', async function(assert) {
 
   // Arrange
   const serializedSnapshot = {
-    '/blogPosts/post_c/message': 'Message',
-    '/blogPosts/post_c/timestamp': 12345,
+    'blogPosts/post_c/message': 'Message',
+    'blogPosts/post_c/timestamp': firebase.database.ServerValue.TIMESTAMP,
+    'userFeeds/user_a/post_c': true,
+    'userFeeds/user_b/post_c': true,
   };
   const spy = sinon.spy(this.ref, 'update');
   const adapter = this.subject({
@@ -75,24 +78,24 @@ test('should update Firebase', async function(assert) {
   });
 
   // Act
-  await adapter.updateRecord(this.store, this.type, {
+  await adapter.createRecord(this.store, this.type, {
     id: 'post_c',
     message: 'Message',
-    timestamp: 12345,
+    timestamp: firebase.database.ServerValue.TIMESTAMP,
     adapterOptions: {
       include: {
-        '/userFeeds/user_a/post_c': true,
-        '/userFeeds/user_b/post_c': true,
+        'userFeeds/user_a/post_c': true,
+        'userFeeds/user_b/post_c': true,
       },
     },
   });
 
   // Assert
   assert.ok(spy.calledWith({
-    '/blogPosts/post_c/message': 'Message',
-    '/blogPosts/post_c/timestamp': 12345,
-    '/userFeeds/user_a/post_c': true,
-    '/userFeeds/user_b/post_c': true,
+    'blogPosts/post_c/message': 'Message',
+    'blogPosts/post_c/timestamp': firebase.database.ServerValue.TIMESTAMP,
+    'userFeeds/user_a/post_c': true,
+    'userFeeds/user_b/post_c': true,
   }));
 });
 
@@ -101,8 +104,8 @@ test('should push realtime changes to store', async function(assert) {
 
   // Arrange
   const serializedSnapshot = {
-    '/blogPosts/post_c/message': 'Message',
-    '/blogPosts/post_c/timestamp': 12345,
+    'blogPosts/post_c/message': 'Message',
+    'blogPosts/post_c/timestamp': firebase.database.ServerValue.TIMESTAMP,
   };
   const spy = sinon.spy(this.store, 'push');
   const adapter = this.subject({
@@ -114,7 +117,7 @@ test('should push realtime changes to store', async function(assert) {
   await adapter.createRecord(this.store, this.type, {
     id: 'post_c',
     message: 'Message',
-    timestamp: 12345,
+    timestamp: firebase.database.ServerValue.TIMESTAMP,
   });
   await this.ref.child('blogPosts/post_c').update({ 'message': 'Foo' });
 
@@ -129,8 +132,8 @@ test('should track Firebase listeners without path when not in FastBoot', async 
 
   // Arrange
   const serializedSnapshot = {
-    '/blogPosts/post_c/message': 'Message',
-    '/blogPosts/post_c/timestamp': 12345,
+    'blogPosts/post_c/message': 'Message',
+    'blogPosts/post_c/timestamp': firebase.database.ServerValue.TIMESTAMP,
   };
   const adapter = this.subject({
     firebase: this.ref,
@@ -141,7 +144,7 @@ test('should track Firebase listeners without path when not in FastBoot', async 
   await adapter.createRecord(this.store, this.type, {
     id: 'post_c',
     message: 'Message',
-    timestamp: 12345,
+    timestamp: firebase.database.ServerValue.TIMESTAMP,
   });
   const result = adapter.get('trackedListeners');
 
@@ -154,8 +157,9 @@ test('should track Firebase listeners with path when not in FastBoot', async fun
 
   // Arrange
   const serializedSnapshot = {
-    '/comments/post_a/comment_c/message': 'Message',
-    '/comments/post_a/comment_c/timestamp': 12345,
+    'comments/post_a/comment_c/message': 'Message',
+    'comments/post_a/comment_c/timestamp':
+        firebase.database.ServerValue.TIMESTAMP,
   };
   const adapter = this.subject({
     firebase: this.ref,
@@ -166,7 +170,7 @@ test('should track Firebase listeners with path when not in FastBoot', async fun
   await adapter.createRecord(this.store, { modelName: 'comment' }, {
     id: 'comment_a',
     message: 'Message',
-    timestamp: 12345,
+    timestamp: firebase.database.ServerValue.TIMESTAMP,
     adapterOptions: { path: 'comments/post_a' },
   });
   const result = adapter.get('trackedListeners');
@@ -180,8 +184,8 @@ test('should not track Firebase listeners when in FastBoot', async function(asse
 
   // Arrange
   const serializedSnapshot = {
-    '/blogPosts/post_c/message': 'Message',
-    '/blogPosts/post_c/timestamp': 12345,
+    'blogPosts/post_c/message': 'Message',
+    'blogPosts/post_c/timestamp': firebase.database.ServerValue.TIMESTAMP,
   };
   const adapter = this.subject({
     firebase: this.ref,
@@ -193,7 +197,7 @@ test('should not track Firebase listeners when in FastBoot', async function(asse
   await adapter.createRecord(this.store, this.type, {
     id: 'post_c',
     message: 'Message',
-    timestamp: 12345,
+    timestamp: firebase.database.ServerValue.TIMESTAMP,
   });
   const result = adapter.get('trackedListeners');
 
@@ -206,8 +210,8 @@ test('should not duplicate pushing realtime changes to store', async function(as
 
   // Arrange
   const serializedSnapshot = {
-    '/blogPosts/post_c/message': 'Message',
-    '/blogPosts/post_c/timestamp': 12345,
+    'blogPosts/post_c/message': 'Message',
+    'blogPosts/post_c/timestamp': firebase.database.ServerValue.TIMESTAMP,
   };
   const spy = sinon.spy(this.store, 'push');
   const adapter = this.subject({
@@ -220,7 +224,7 @@ test('should not duplicate pushing realtime changes to store', async function(as
   await adapter.createRecord(this.store, this.type, {
     id: 'post_c',
     message: 'Message',
-    timestamp: 12345,
+    timestamp: firebase.database.ServerValue.TIMESTAMP,
   });
 
   // Assert
@@ -233,8 +237,8 @@ test('should unload record when it gets deleted from the backend', async functio
   // Arrange
   const record = EmberObject.create({ isSaving: false });
   const serializedSnapshot = {
-    '/blogPosts/post_c/message': 'Message',
-    '/blogPosts/post_c/timestamp': 12345,
+    'blogPosts/post_c/message': 'Message',
+    'blogPosts/post_c/timestamp': firebase.database.ServerValue.TIMESTAMP,
   };
   const stub = sinon.stub();
 
@@ -254,9 +258,9 @@ test('should unload record when it gets deleted from the backend', async functio
   await adapter.createRecord(this.store, this.type, {
     id: 'post_c',
     message: 'Message',
-    timestamp: 12345,
+    timestamp: firebase.database.ServerValue.TIMESTAMP,
   });
-  await this.ref.child('/blogPosts/post_c').remove();
+  await this.ref.child('blogPosts/post_c').remove();
 
   // Assert
   assert.ok(stub.calledWithExactly(record));
@@ -283,8 +287,10 @@ test('should update Firebase when updating a record', async function(assert) {
 
   // Arrange
   const serializedSnapshot = {
-    '/blogPosts/post_a/message': 'Message',
-    '/blogPosts/post_a/timestamp': 12345,
+    'blogPosts/post_a/message': 'Message',
+    'blogPosts/post_a/timestamp': firebase.database.ServerValue.TIMESTAMP,
+    'userFeeds/user_a/post_a': true,
+    'userFeeds/user_b/post_a': true,
   };
   const spy = sinon.spy(this.ref, 'update');
   const adapter = this.subject({
@@ -296,21 +302,21 @@ test('should update Firebase when updating a record', async function(assert) {
   await adapter.updateRecord(this.store, this.type, {
     id: 'post_a',
     message: 'Message',
-    timestamp: 12345,
+    timestamp: firebase.database.ServerValue.TIMESTAMP,
     adapterOptions: {
       include: {
-        '/userFeeds/user_a/post_a': true,
-        '/userFeeds/user_b/post_a': true,
+        'userFeeds/user_a/post_a': true,
+        'userFeeds/user_b/post_a': true,
       },
     },
   });
 
   // Assert
   assert.ok(spy.calledWith({
-    '/blogPosts/post_a/message': 'Message',
-    '/blogPosts/post_a/timestamp': 12345,
-    '/userFeeds/user_a/post_a': true,
-    '/userFeeds/user_b/post_a': true,
+    'blogPosts/post_a/message': 'Message',
+    'blogPosts/post_a/timestamp': firebase.database.ServerValue.TIMESTAMP,
+    'userFeeds/user_a/post_a': true,
+    'userFeeds/user_b/post_a': true,
   }));
 });
 
@@ -348,7 +354,7 @@ test('should return fetched record', async function(assert) {
   assert.deepEqual(result, {
     id: 'post_a',
     message: 'Post A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_a',
     _innerReferencePath: '',
   });
@@ -479,7 +485,7 @@ test('should unload record when it gets deleted from the backend', async functio
 
   // Act
   await adapter.findRecord(this.store, this.type, 'post_a');
-  await this.ref.child('/blogPosts/post_a').remove();
+  await this.ref.child('blogPosts/post_a').remove();
 
   // Arrange
   assert.ok(stub.calledWithExactly(record));
@@ -610,9 +616,9 @@ test('should push realtime child_added changes to store after finding all record
 
   // Act
   await adapter.findAll(this.store, this.type);
-  await this.ref.child('/blogPosts/post_c').update({
+  await this.ref.child('blogPosts/post_c').update({
     message: 'Post C',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_a',
   });
 
@@ -649,7 +655,7 @@ test('should remove record from Firebase when deleting a record without path', a
   await adapter.deleteRecord({}, { modelName: 'blog-post' }, {
     id: 'post_a',
     message: 'Post A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_a',
     adapterOptions: { include: { 'users/user_a': null } },
   });
@@ -671,7 +677,7 @@ test('should remove record from Firebase when deleting a record with path', asyn
   await adapter.deleteRecord({}, { modelName: 'comment' }, {
     id: 'comment_a',
     message: 'Comment A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
     adapterOptions: { path: 'comments/post_a' },
   });
@@ -799,7 +805,7 @@ test('should return a single record that matches the path query params', async f
 
   // Act
   const result = await adapter.queryRecord(this.store, this.type, {
-    path: '/userFeeds/user_a/',
+    path: 'userFeeds/user_a/',
   });
 
   // Assert
@@ -985,7 +991,7 @@ test('should return records that matches the path query params', async function(
 
   // Act
   const result = await adapter.query(this.store, this.type, {
-    path: '/userFeeds/user_a',
+    path: 'userFeeds/user_a',
   }, this.recordArray);
 
   // Assert
@@ -1024,9 +1030,9 @@ test('should listen for child_added changes when query params has cacheId and no
     cacheId: 'foo',
   }, this.recordArray);
   await this.ref.update({
-    '/blogPosts/post_c': {
+    'blogPosts/post_c': {
       message: 'Post C',
-      timestamp: 12345,
+      timestamp: 1483228800000,
       author: 'user_a',
     },
   });
@@ -1054,9 +1060,9 @@ test('should not listen for child_added changes when query params has cacheId an
     cacheId: 'foo',
   }, this.recordArray);
   await this.ref.update({
-    '/blogPosts/post_c': {
+    'blogPosts/post_c': {
       message: 'Post C',
-      timestamp: 12345,
+      timestamp: 1483228800000,
       author: 'user_a',
     },
   });
@@ -1078,7 +1084,7 @@ test('should listen for child_removed changes when query params has cacheId and 
   await adapter.query(this.store, this.type, {
     cacheId: 'foo',
   }, this.recordArray);
-  await this.ref.update({ '/blogPosts/post_a': null });
+  await this.ref.update({ 'blogPosts/post_a': null });
 
   // Assert
   assert.deepEqual(this.recordArray.get('content'), [
@@ -1100,7 +1106,7 @@ test('should not listen for child_removed changes when query params has cacheId 
   await adapter.query(this.store, this.type, {
     cacheId: 'foo',
   }, this.recordArray);
-  await this.ref.update({ '/blogPosts/post_a': null });
+  await this.ref.update({ 'blogPosts/post_a': null });
 
   // Assert
   assert.deepEqual(this.recordArray.get('content'), []);

--- a/tests/unit/serializers/firebase-flex-test.js
+++ b/tests/unit/serializers/firebase-flex-test.js
@@ -1,7 +1,9 @@
 import { moduleForModel, test } from 'ember-qunit';
 
+import firebase from 'firebase';
+
 moduleForModel('blog-post', 'Unit | Serializer | firebase flex', {
-  needs: [ 'model:user', 'serializer:application' ],
+  needs: [ 'model:user', 'serializer:application', 'transform:timestamp' ],
 });
 
 test('should serialize record to Firebase fanout', function(assert) {
@@ -11,7 +13,7 @@ test('should serialize record to Firebase fanout', function(assert) {
   const post = this.subject({
     id: 'post_a',
     message: 'Post',
-    timestamp: 12345,
+    timestamp: firebase.database.ServerValue.TIMESTAMP,
   });
 
   // Act
@@ -19,28 +21,30 @@ test('should serialize record to Firebase fanout', function(assert) {
 
   // Assert
   assert.deepEqual(serializedRecord, {
-    '/blogPosts/post_a/message': 'Post',
-    '/blogPosts/post_a/timestamp': 12345,
+    'blogPosts/post_a/message': 'Post',
+    'blogPosts/post_a/timestamp': firebase.database.ServerValue.TIMESTAMP,
   });
 });
 
-test('should remove _innerReferencePath from fanout', function(assert) {
+test('should remove inner reference path from fanout', function(assert) {
   assert.expect(1);
 
   // Arrange
   const post = this.subject({
     id: 'post_a',
     message: 'Post',
-    timestamp: 12345,
-    _innerReferencePath: '/post_a',
+    timestamp: firebase.database.ServerValue.TIMESTAMP,
+    innerReferencePath: 'post_a',
   });
 
   // Act
-  const serializedRecord = post.serialize();
+  const serializedRecord = post.serialize({
+    innerReferencePathName: 'innerReferencePath',
+  });
 
   // Assert
   assert.deepEqual(serializedRecord, {
-    '/blogPosts/post_a/message': 'Post',
-    '/blogPosts/post_a/timestamp': 12345,
+    'blogPosts/post_a/message': 'Post',
+    'blogPosts/post_a/timestamp': firebase.database.ServerValue.TIMESTAMP,
   });
 });

--- a/tests/unit/services/firebase-util-test.js
+++ b/tests/unit/services/firebase-util-test.js
@@ -309,7 +309,7 @@ test('should return a record that matches the equalTo params', async function(as
   assert.deepEqual(result, {
     id: 'comment_b',
     message: 'Comment B',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   });
 });
@@ -329,7 +329,7 @@ test('should return a record that matches the startAt params', async function(as
   assert.deepEqual(result, {
     id: 'comment_a',
     message: 'Comment A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   });
 });
@@ -349,7 +349,7 @@ test('should return a record that matches the endAt params', async function(asse
   assert.deepEqual(result, {
     id: 'comment_a',
     message: 'Comment A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   });
 });
@@ -388,7 +388,7 @@ test('should update in realtime when cacheId is provided', async function(assert
   assert.deepEqual(result, {
     id: 'comment_a',
     message: 'Foo',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   });
 });
@@ -413,7 +413,7 @@ test('should return cached record when available', async function(assert) {
   assert.deepEqual(result, {
     id: 'comment_a',
     message: 'Comment A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   });
 });
@@ -447,12 +447,12 @@ test('should return records ordered by key', async function(assert) {
   assert.deepEqual(result, [{
     id: 'comment_a',
     message: 'Comment A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }, {
     id: 'comment_b',
     message: 'Comment B',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }]);
 });
@@ -472,7 +472,7 @@ test('should return records matching the equalTo param', async function(assert) 
   assert.deepEqual(result, [{
     id: 'comment_a',
     message: 'Comment A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }]);
 });
@@ -492,12 +492,12 @@ test('should return records matching the startAt param', async function(assert) 
   assert.deepEqual(result, [{
     id: 'comment_a',
     message: 'Comment A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }, {
     id: 'comment_b',
     message: 'Comment B',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }]);
 });
@@ -517,7 +517,7 @@ test('should return records matching the endAt param', async function(assert) {
   assert.deepEqual(result, [{
     id: 'comment_b',
     message: 'Comment B',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }]);
 });
@@ -537,7 +537,7 @@ test('should return records matching the limitToFirst param', async function(ass
   assert.deepEqual(result, [{
     id: 'comment_a',
     message: 'Comment A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }]);
 });
@@ -557,7 +557,7 @@ test('should return records matching the limitToLast param', async function(asse
   assert.deepEqual(result, [{
     id: 'comment_b',
     message: 'Comment B',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }]);
 });
@@ -592,7 +592,7 @@ test('should update query array in realtime when cacheId is provided', async fun
   await service.update({
     'comments/post_a/comment_c': {
       message: 'Comment C',
-      timestamp: 12345,
+      timestamp: 1483228800000,
       author: 'user_b',
     },
   });
@@ -601,7 +601,7 @@ test('should update query array in realtime when cacheId is provided', async fun
   assert.deepEqual(result, [{
     id: 'comment_c',
     message: 'Comment C',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }]);
 });
@@ -624,7 +624,7 @@ test('should update query record in realtime when cacheId is provided', async fu
   assert.deepEqual(result, [{
     id: 'comment_a',
     message: 'Foo',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }]);
 });
@@ -649,7 +649,7 @@ test('should return cached records when available', async function(assert) {
   assert.deepEqual(result, [{
     id: 'comment_a',
     message: 'Comment A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }]);
 });
@@ -672,12 +672,12 @@ test('should load next limitToFirst records when requesting it', async function(
   assert.deepEqual(result, [{
     id: 'comment_a',
     message: 'Comment A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }, {
     id: 'comment_b',
     message: 'Comment B',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }]);
 });
@@ -700,12 +700,12 @@ test('should load next limitToLast records when requesting it', async function(a
   assert.deepEqual(result, [{
     id: 'comment_a',
     message: 'Comment A',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }, {
     id: 'comment_b',
     message: 'Comment B',
-    timestamp: 12345,
+    timestamp: 1483228800000,
     author: 'user_b',
   }]);
 });

--- a/tests/unit/transforms/timestamp-test.js
+++ b/tests/unit/transforms/timestamp-test.js
@@ -1,0 +1,31 @@
+import { moduleFor, test } from 'ember-qunit';
+
+import firebase from 'firebase';
+
+moduleFor('transform:timestamp', 'Unit | Transform | timestamp');
+
+test('should serialize to Firebase server value timestamp', function(assert) {
+  assert.expect(1);
+
+  // Arrange
+  const transform = this.subject();
+
+  // Act
+  const result = transform.serialize();
+
+  // Assert
+  assert.deepEqual(result, firebase.database.ServerValue.TIMESTAMP);
+});
+
+test('should deserialize to date', function(assert) {
+  assert.expect(1);
+
+  // Arrange
+  const transform = this.subject();
+
+  // Act
+  const result = transform.deserialize(1483228800000);
+
+  // Assert
+  assert.deepEqual(result, new Date('2017-01-01'));
+});

--- a/tests/unit/utils/has-filtered-test.js
+++ b/tests/unit/utils/has-filtered-test.js
@@ -13,6 +13,9 @@ test('should return a computed promise array when calling hasFiltered', function
   assert.expect(2);
 
   // Arrange
+  const adapterForStub = sinon.stub().returns(EmberObject.create({
+    innerReferencePathName: 'innerReferencePath',
+  }));
   const queryResult = [{
     id: 'xfoo',
     value: 'foo',
@@ -25,14 +28,14 @@ test('should return a computed promise array when calling hasFiltered', function
   }];
   const queryStub = sinon.stub().returns(stubPromise(true, queryResult));
   const EO = EmberObject.extend({
-    store: { query: queryStub },
+    store: { adapterFor: adapterForStub, query: queryStub },
 
     id: 'lala',
-    _innerReferencePath: 'land',
+    innerReferencePath: 'land',
 
     foo: hasFiltered('model', {
-      cacheId: 'foo_$id',
-      path: 'foo_$id_bar_$innerReferencePath',
+      cacheId: 'foo_:id',
+      path: 'foo_:id_bar_:innerReferencePath',
     }),
   });
   const object = EO.create();


### PR DESCRIPTION
- [x] Rewrite code basing it on JSONSerializer
- [x] Move `adapterOptions.include` to serializer
- [x] Add `timestamp` transform (a more explicit transform for `firebase.database.ServerValue.TIMESTAMP`) 
- [x] Add option to specify what attribute will hold the inner reference path per model.